### PR TITLE
Update velodyne scanning rate

### DIFF
--- a/Assets/Scripts/LiDAR/Lidar.cs
+++ b/Assets/Scripts/LiDAR/Lidar.cs
@@ -16,6 +16,7 @@ public class Lidar : MonoBehaviour {
     [HideInInspector]
     public float[] distances;
     public float[] azimuts;
+    private bool isInitialized = false;
 
 
     // Use this for initialization
@@ -24,10 +25,11 @@ public class Lidar : MonoBehaviour {
         azimuts = new float[numberOfIncrements];
         vertIncrement = (float)(maxAngle - minAngle) / (float)(numberOfLayers - 1);
         azimutIncrAngle = (float)(360.0f / numberOfIncrements);
+        isInitialized = true;
     }
 
 // Update is called once per frame
-void FixedUpdate () {
+    public void Scan () {
         Vector3 fwd = new Vector3(0, 0, 1);
         Vector3 dir;
         RaycastHit hit;
@@ -58,5 +60,9 @@ void FixedUpdate () {
             }
         }
 
+    }
+
+    public bool IsInitialized () {
+        return isInitialized;
     }
 }

--- a/Assets/Scripts/Velodyne/VelodynePublisher.cs
+++ b/Assets/Scripts/Velodyne/VelodynePublisher.cs
@@ -164,7 +164,7 @@ namespace RosSharp.RosBridgeClient
                         PublishVelodyneData();
                     }
                 }
-                yield return new WaitForSeconds(processInterval);
+                yield return null;
             }
         }
     }

--- a/Assets/Scripts/Velodyne/VelodynePublisher.cs
+++ b/Assets/Scripts/Velodyne/VelodynePublisher.cs
@@ -13,7 +13,6 @@ namespace RosSharp.RosBridgeClient
         private List<MessageTypes.Velodyne.VelodynePacket> packets;
         private int[] laserIdxs1 = { 0,8 ,1,9, 2,10, 3,11, 4,12, 5,13, 6,14,  7, 15};
         private float elapsedTime = 0.0f;
-        private const float processInterval = 0.001f;
         public int numDataBlocks = 12;
         public static DateTime UNIX_EPOCH = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         public float rate = 10.0f;
@@ -157,7 +156,7 @@ namespace RosSharp.RosBridgeClient
             {
                 if (lidar.IsInitialized())
                 {
-                    if (Time.time > elapsedTime - processInterval)
+                    if (Time.time >= elapsedTime)
                     {
                         elapsedTime = Time.time + 1.0f / rate;
                         lidar.Scan();

--- a/Assets/Scripts/Velodyne/VelodynePublisher.cs
+++ b/Assets/Scripts/Velodyne/VelodynePublisher.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace RosSharp.RosBridgeClient
 {
@@ -10,8 +12,11 @@ namespace RosSharp.RosBridgeClient
         private MessageTypes.Velodyne.VelodyneScan message;
         private List<MessageTypes.Velodyne.VelodynePacket> packets;
         private int[] laserIdxs1 = { 0,8 ,1,9, 2,10, 3,11, 4,12, 5,13, 6,14,  7, 15};
+        private float elapsedTime = 0.0f;
+        private const float processInterval = 0.001f;
         public int numDataBlocks = 12;
         public static DateTime UNIX_EPOCH = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        public float rate = 10.0f;
 
         public virtual MessageTypes.Std.Time Now()
         {
@@ -32,6 +37,7 @@ namespace RosSharp.RosBridgeClient
             base.Start();
             lidar = gameObject.GetComponent<Lidar>();
             InitializeMessage();
+            StartCoroutine("Process");
         }
 
         private void InitializeMessage()
@@ -118,7 +124,8 @@ namespace RosSharp.RosBridgeClient
             return result;
         }
 
-        private void Update()
+        // private void Update()
+        private void PublishVelodyneData()
         {
             Boolean cont = true;
             int idx = 0;
@@ -142,6 +149,23 @@ namespace RosSharp.RosBridgeClient
             message.header.stamp = Now();
             message.packets = packets.ToArray();
             Publish(message);
+        }
+
+        IEnumerator Process()
+        {
+            while (true)
+            {
+                if (lidar.IsInitialized())
+                {
+                    if (Time.time > elapsedTime - processInterval)
+                    {
+                        elapsedTime = Time.time + 1.0f / rate;
+                        lidar.Scan();
+                        PublishVelodyneData();
+                    }
+                }
+                yield return new WaitForSeconds(processInterval);
+            }
         }
     }
 }


### PR DESCRIPTION
`/velodyne_packets`のpublish rateを改善しました
`Number Of Increments `を1800に設定した場合の`rostopic hz`の結果は以下の通りです

- `develop`ブランチ
```
$ rostopic hz /velodyne_packets
subscribed to [/velodyne_packets]
average rate: 1.957
	min: 0.511s max: 0.511s std dev: 0.00000s window: 2
average rate: 2.030
	min: 0.479s max: 0.511s std dev: 0.01356s window: 4
average rate: 2.066
	min: 0.451s max: 0.511s std dev: 0.01817s window: 7
average rate: 2.060
	min: 0.451s max: 0.511s std dev: 0.01635s window: 9
average rate: 2.051
	min: 0.451s max: 0.516s std dev: 0.01759s window: 11
```

- このPRのブランチ (10Hzに設定した場合)
```
$ rostopic hz /velodyne_packets
subscribed to [/velodyne_packets]
average rate: 10.039
	min: 0.093s max: 0.108s std dev: 0.00462s window: 9
average rate: 9.984
	min: 0.093s max: 0.109s std dev: 0.00417s window: 19
average rate: 9.976
	min: 0.093s max: 0.109s std dev: 0.00393s window: 29
average rate: 9.978
	min: 0.091s max: 0.109s std dev: 0.00461s window: 39
average rate: 9.976
	min: 0.091s max: 0.109s std dev: 0.00458s window: 49
```

(PCスペックはCore i7-7700/16GB。UnityはWindows10、ROSはWSLで動作)