### PR TITLE
Fix Lidar lag spike from RaycastLiDARSensor.cs

### DIFF
--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
@@ -91,7 +91,7 @@ namespace UnitySensors.Sensor.LiDAR
 
             JobHandle updateRaycastCommandsJobHandle = _updateRaycastCommandsJob.Schedule(pointsNum, 1);
             JobHandle updateGaussianNoisesJobHandle = _updateGaussianNoisesJob.Schedule(pointsNum, 1, updateRaycastCommandsJobHandle);
-            JobHandle raycastJobHandle = RaycastCommand.ScheduleBatch(_raycastCommands, _raycastHits, pointsNum, updateGaussianNoisesJobHandle);
+            JobHandle raycastJobHandle = RaycastCommand.ScheduleBatch(_raycastCommands, _raycastHits, 256, updateGaussianNoisesJobHandle);
             _jobHandle = _raycastHitsToPointsJob.Schedule(pointsNum, 1, raycastJobHandle);
 
             JobHandle.ScheduleBatchedJobs();


### PR DESCRIPTION
Fixed a performance bug when using lidar by changing the minimum raycast calculation per job.

As we see in the unity editor's profiling tool, there's a lag spike every time lidar run, and a single job seems to perform all the calculations.

![Screenshot from 2024-09-12 15-58-44](https://github.com/user-attachments/assets/001fca98-3c6b-4fe8-a3cd-7f33a11f0b82)

After changing the `minCommandsPerJob` parameter from `RaycastCommand.ScheduleBatch` inside `RaycastLiDARSensor.cs` with a constant value of `256` (arbitrary value), we can see an improvement: there are no more lag peaks, the frame rate is now stable and tasks are better distributed between jobs.

![after](https://github.com/user-attachments/assets/f10fddc3-3878-421d-8e5d-d0c385b0837c)