### PR TITLE
Fix camera limitation due to jpg encoding

### DIFF
--- a/Assets/UnitySensors/Runtime/Scripts/Data/Texture/ITextureInterface.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Data/Texture/ITextureInterface.cs
@@ -5,5 +5,9 @@ namespace UnitySensors.Data.Texture
     public interface ITextureInterface
     {
         public Texture2D texture { get; }
+        public byte[] data { get; }
+        public int width { get; }
+        public int height { get; }
+        public string encoding { get; }
     }
 }

--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/Camera/CameraSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/Camera/CameraSensor.cs
@@ -20,11 +20,17 @@ namespace UnitySensors.Sensor.Camera
         private UnityEngine.Camera _m_camera;
         private RenderTexture _rt = null;
         private Texture2D _texture;
+        private byte[] _data;
 
         public Vector2Int resolution { get => _resolution; }
         protected float maxRange { get => _maxRange; }
         public UnityEngine.Camera m_camera { get => _m_camera; }
         public Texture2D texture { get => _texture; }
+        public byte[] data { get => _data; }
+        public int width { get => _resolution.x; }
+        public int height { get => _resolution.y; }
+        public string encoding { get => "rgb8"; }
+
 
         protected override void Init()
         {
@@ -33,16 +39,18 @@ namespace UnitySensors.Sensor.Camera
             _m_camera.nearClipPlane = _minRange;
             _m_camera.farClipPlane = _maxRange;
 
-            _rt = new RenderTexture(_resolution.x, _resolution.y, 32, RenderTextureFormat.ARGBFloat);
+            _rt = new RenderTexture(_resolution.x, _resolution.y, 16, RenderTextureFormat.ARGB32);
             _m_camera.targetTexture = _rt;
 
-            _texture = new Texture2D(_resolution.x, _resolution.y, TextureFormat.RGBAFloat, false);
+            _texture = new Texture2D(width, height, TextureFormat.RGB24, false);
+
+            _data = new byte[width * height * 3];
         }
 
         protected override void UpdateSensor()
         {
             if (!LoadTexture()) return;
-            
+
             if (onSensorUpdated != null)
                 onSensorUpdated.Invoke();
         }
@@ -50,15 +58,31 @@ namespace UnitySensors.Sensor.Camera
         protected bool LoadTexture()
         {
             bool result = false;
-            AsyncGPUReadback.Request(_rt, 0, request => {
-                if (request.hasError)
-                {
-                }
-                else
-                {
-                    var data = request.GetData<Color>();
-                    _texture.LoadRawTextureData(data);
+
+            // Blit to a temporary texture and request readback on it.
+            AsyncGPUReadback.Request(_rt, 0, TextureFormat.ARGB32, request => {
+                if (request.hasError) {
+                    Debug.LogWarning("GPU readback error was detected.");
+                } else {
+                    var dataBuffer = request.GetData<byte>();
+
+                    // Flip image
+                    int i=0;
+                    int j=width*(height-1)*4;
+                    for(int y=0; y<height; y++){
+                        for(int x=0; x<width; x++) {
+                            _data[i+0] = dataBuffer[j+1];
+                            _data[i+1] = dataBuffer[j+2];
+                            _data[i+2] = dataBuffer[j+3];
+                            i+=3;
+                            j+=4;
+                        }
+                        j -= width << 3; // width * 2 * 3;
+                    }
+
+                    _texture.LoadRawTextureData(_data);
                     _texture.Apply();
+
                     result = true;
                 }
             });
@@ -68,7 +92,13 @@ namespace UnitySensors.Sensor.Camera
 
         protected override void OnSensorDestroy()
         {
-            _rt.Release();
+            if (_rt != null)
+            {
+                // Dispose the frame texture.
+                m_camera.targetTexture = null;
+                Destroy(_rt);
+                _rt = null;
+            }
         }
     }
 }

--- a/Assets/UnitySensorsROS/Runtime/Prefabs/Camera/DepthCamera_ros.prefab
+++ b/Assets/UnitySensorsROS/Runtime/Prefabs/Camera/DepthCamera_ros.prefab
@@ -109,7 +109,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _frequency: 10
-  _topicName: /camera/depth/image/compressed
+  _topicName: /camera/depth/image
   _serializer:
     _header:
       _frame_id: /camera_frame

--- a/Assets/UnitySensorsROS/Runtime/Prefabs/Camera/RGBCamera_ros.prefab
+++ b/Assets/UnitySensorsROS/Runtime/Prefabs/Camera/RGBCamera_ros.prefab
@@ -108,7 +108,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _frequency: 10
-  _topicName: /camera/color/image/compressed
+  _topicName: /camera/color/image
   _serializer:
     _header:
       _frame_id: /camera_frame

--- a/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/Image/ImageMsgPublisher.cs
+++ b/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/Image/ImageMsgPublisher.cs
@@ -6,7 +6,7 @@ using UnitySensors.ROS.Serializer.Image;
 
 namespace UnitySensors.ROS.Publisher.Image
 {
-    public class ImageMsgPublisher<T> : RosMsgPublisher<T, ImageMsgSerializer<T>, CompressedImageMsg> where T : UnitySensor, ITextureInterface
+    public class ImageMsgPublisher<T> : RosMsgPublisher<T, ImageMsgSerializer<T>, ImageMsg> where T : UnitySensor, ITextureInterface
     {
     }
 }

--- a/Assets/UnitySensorsROS/Runtime/Scripts/Serializers/Image/ImageMsgSerializer.cs
+++ b/Assets/UnitySensorsROS/Runtime/Scripts/Serializers/Image/ImageMsgSerializer.cs
@@ -7,25 +7,27 @@ using UnitySensors.Sensor;
 namespace UnitySensors.ROS.Serializer.Image
 {
     [System.Serializable]
-    public class ImageMsgSerializer<T> : RosMsgSerializer<T, CompressedImageMsg> where T : UnitySensor, ITextureInterface
+    public class ImageMsgSerializer<T> : RosMsgSerializer<T, ImageMsg> where T : UnitySensor, ITextureInterface
     {
         [SerializeField]
         private HeaderSerializer _header;
-        [SerializeField, Range(1, 100)]
-        private int quality = 75;
 
         public override void Init(T sensor)
         {
             base.Init(sensor);
             _header.Init(sensor);
 
-            _msg.format = "jpeg";
+            _msg.height       = (uint)sensor.height;
+            _msg.width        = (uint)sensor.width;
+            _msg.encoding     = sensor.encoding;
+            _msg.is_bigendian = 0;
+            _msg.step         = 1 * 3 * _msg.width;
         }
 
-        public override CompressedImageMsg Serialize()
+        public override ImageMsg Serialize()
         {
             _msg.header = _header.Serialize();
-            _msg.data = sensor.texture.EncodeToJPG(quality);
+            _msg.data = sensor.data;
             return _msg;
         }
     }


### PR DESCRIPTION
I noticed that the camera sensor was limited in resolution and frequency, by default is set to `640x480 10fps`, when trying to increase that the frame rate was falling down to `6/7fps` on a Quadro RTX 5000.

After looking in the code and searching for a performance bottleneck with unity profiling tool, I find out that the image where send in `CompressedImage` format made from [`Texture2D.EncodeToJPG()`](https://docs.unity3d.com/560/Documentation/ScriptReference/Texture2D.EncodeToJPG.html).
This method was intended for screenshots purpose and not real-time encoding.
Following [ZeroSimROSUnity](https://github.com/fsstudio-team/ZeroSimROSUnity) camera sensor implementation, a good way is to simply send raw buffer without any encoding, allowing high quality.

![Screenshot from 2024-09-24 17-58-49](https://github.com/user-attachments/assets/50004e6b-5a6c-4ec6-b0bc-2f686329a089)
![Screenshot from 2024-09-24 17-58-56](https://github.com/user-attachments/assets/cc7f8288-4711-483d-8f54-7de944e7747e)

Now running the simulation at `140fps` in the demo scene, using camera sensor of `1920x1080 at 20fps` (Running on Ubuntu 22.04 with Quadro RTX 5000).


> [!WARNING]  
> The depth camera may be broken I didn't check.
