### PR TITLE
[HotFix] Delete unnecessary ai.navigate package

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": "1.1.5",
     "com.unity.burst": "1.8.18",
     "com.unity.collab-proxy": "2.5.1",
     "com.unity.ide.rider": "3.0.31",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,5 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": {
-      "version": "1.1.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.ai": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.burst": {
       "version": "1.8.18",
       "depth": 0,


### PR DESCRIPTION
# About
I deleted `ai.navigation` package from depends.
This package is not supported in unity before 2022.3.x.
That is why we are failing to support and CI tests before 2022.3.x versions.
With this modification, we solve those problems.