### PR TITLE
Fix for compiling Unity Player executable

### DIFF
--- a/Assets/UnitySensors/Editor/UnitySensorsEditor.asmdef
+++ b/Assets/UnitySensors/Editor/UnitySensorsEditor.asmdef
@@ -5,7 +5,7 @@
         "GUID:d8b63aba1907145bea998dd612889d6b",
         "GUID:e9a473e6ad03eae4a89800bf81bd1594"
     ],
-    "includePlatforms": [],
+    "includePlatforms": ["Editor"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Assets/UnitySensorsROS/Editor/UnitySensorsROSEditor.asmdef
+++ b/Assets/UnitySensorsROS/Editor/UnitySensorsROSEditor.asmdef
@@ -4,7 +4,7 @@
     "references": [
         "GUID:fa38f881a10f6314fa784b8975c16eff"
     ],
-    "includePlatforms": [],
+    "includePlatforms": ["Editor"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
The current version of the Unity packages fails when trying to build a Standalone Executable Unity Player, with the UnitySensors packages included.

This is because the assembly definitions do not flag the Editor folders to only be included in Editor builds.

I have created a very simple fork to fix this in my own project for time being, but I thought it would be nice to share it back to the main project, so we do not have to use this workaround.