### PR TITLE
Made it possible to initialize LiDARSensor later so that it works with the built app.

### DIFF
--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/DepthBufferLiDAR/DepthBufferLiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/DepthBufferLiDAR/DepthBufferLiDARSensor.cs
@@ -40,6 +40,7 @@ namespace UnitySensors.Sensor.LiDAR
         {
             if (scanPattern == null)
             {
+                Debug.LogWarning("Initialization postponed: scanPattern is null. Ensure that scanPattern is assigned before calling Init.");
                 return;
             }
             Initialize();

--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/DepthBufferLiDAR/DepthBufferLiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/DepthBufferLiDAR/DepthBufferLiDARSensor.cs
@@ -38,7 +38,16 @@ namespace UnitySensors.Sensor.LiDAR
 
         protected override void Init()
         {
-            base.Init();
+            if (scanPattern == null)
+            {
+                return;
+            }
+            Initialize();
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
             _transform = this.transform;
             SetupCamera();
             LoadScanData();

--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/LiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/LiDARSensor.cs
@@ -35,6 +35,15 @@ namespace UnitySensors.Sensor.LiDAR
 
         protected override void Init()
         {
+            if (_scanPattern == null)
+            {
+                return;
+            }
+            Initialize();
+        }
+
+        public virtual void Initialize()
+        {
             _pointsNumPerScan = Mathf.Clamp(_pointsNumPerScan, 1, scanPattern.size);
             _pointCloud = new PointCloud<PointXYZI>()
             {

--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
@@ -30,7 +30,16 @@ namespace UnitySensors.Sensor.LiDAR
 
         protected override void Init()
         {
-            base.Init();
+            if (scanPattern == null)
+            {
+                return;
+            }
+            Initialize();
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
 
             _transform = this.transform;
 

--- a/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
+++ b/Assets/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
@@ -32,6 +32,7 @@ namespace UnitySensors.Sensor.LiDAR
         {
             if (scanPattern == null)
             {
+                Debug.LogWarning("RaycastLiDARSensor: scanPattern is null. Initialization is delayed until scanPattern is set.");
                 return;
             }
             Initialize();

--- a/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
+++ b/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
@@ -14,7 +14,7 @@ namespace UnitySensors.ROS.Publisher.Sensor
         {
             if (_source == null)
             {
-                Debug.LogError("Source is not set.");
+                Debug.LogError("Source is not set in LiDARPointCloud2MsgPublisher. Please ensure that the '_source' field is assigned in the Unity Editor or via code. Expected type: IPointCloudInterface<PointXYZI>.");
                 return;
             }
             _serializer.SetSource(_source as IPointCloudInterface<PointXYZI>);

--- a/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
+++ b/Assets/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
@@ -12,6 +12,11 @@ namespace UnitySensors.ROS.Publisher.Sensor
 
         private void Awake()
         {
+            if (_source == null)
+            {
+                Debug.LogError("Source is not set.");
+                return;
+            }
             _serializer.SetSource(_source as IPointCloudInterface<PointXYZI>);
         }
     }


### PR DESCRIPTION
In the previous version, the simulation was executed after the LiDARSensor settings were completed in the editor, and the Init function was called. However, in the built app, the Init function was called before the settings were made, resulting in a NullReferenceException. To ensure that the app works in the built version as well, I modified the code so that if an element is null, it is not initialized immediately but can be initialized later.