### PR TITLE
Fix incorrect publish frequency for PointCloud2 publishers

### DIFF
--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/RosMsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/RosMsgPublisher.cs
@@ -37,7 +37,13 @@ namespace UnitySensors.ROS.Publisher
         }
         private void Awake()
         {
+            InitializePublisher();
+        }
+
+        protected virtual void InitializePublisher()
+        {
             _frequency_inv = 1.0f / _frequency;
+
             _publisher_id = _publisher_count;
             _publisher_count++;
 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/DepthCameraPointCloud2MsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/DepthCameraPointCloud2MsgPublisher.cs
@@ -11,8 +11,10 @@ namespace UnitySensors.ROS.Publisher.Sensor
         [SerializeField, Interface(typeof(IPointCloudInterface<PointXYZ>))]
         private Object _source;
 
-        private void Awake()
+        protected override void InitializePublisher()
         {
+            base.InitializePublisher();
+
             _serializer.SetSource(_source as IPointCloudInterface<PointXYZ>);
             (_source as DepthCameraSensor).convertToPointCloud = true;
         }

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/LiDARPointCloud2MsgPublisher.cs
@@ -10,8 +10,10 @@ namespace UnitySensors.ROS.Publisher.Sensor
         [SerializeField, Interface(typeof(IPointCloudInterface<PointXYZI>))]
         private Object _source;
 
-        private void Awake()
+        protected override void InitializePublisher()
         {
+            base.InitializePublisher();
+
             if (_source == null)
             {
                 Debug.LogError("Source is not set in LiDARPointCloud2MsgPublisher. Please ensure that the '_source' field is assigned in the Unity Editor or via code. Expected type: IPointCloudInterface<PointXYZI>.");

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/RGBDCameraPointCloud2MsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/SensorMsgs/PointCloud2Msg/RGBDCameraPointCloud2MsgPublisher.cs
@@ -11,8 +11,10 @@ namespace UnitySensors.ROS.Publisher.Sensor
         [SerializeField, Interface(typeof(IPointCloudInterface<PointXYZRGB>))]
         private Object _source;
 
-        private void Awake()
+        protected override void InitializePublisher()
         {
+            base.InitializePublisher();
+
             _serializer.SetSource(_source as IPointCloudInterface<PointXYZRGB>);
             (_source as RGBDCameraSensor).convertToPointCloud = true;
         }


### PR DESCRIPTION
In the base class `RosMsgPublisher`, the `InitializePublisher()` function initializes the publishing frequency to facilitate overriding the initialization logic in subclasses.
This resolves the issue of incorrect publishing frequency in the PointCloud2 Publisher.