### PR TITLE
Fix Lidar output being affected by the gameobject's scale.

### DIFF
--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/IUpdateRaycastCommandsJob.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/IUpdateRaycastCommandsJob.cs
@@ -14,7 +14,7 @@ namespace UnitySensors.Sensor.LiDAR
         [ReadOnly]
         public Vector3 origin;
         [ReadOnly]
-        public Matrix4x4 localToWorldMatrix;
+        public quaternion rotation;
         [ReadOnly]
         public float maxRange;
         [ReadOnly]
@@ -28,7 +28,7 @@ namespace UnitySensors.Sensor.LiDAR
 
         public void Execute(int index)
         {
-            raycastCommands[index] = new(origin, localToWorldMatrix * (Vector3)directions[index + indexOffset], queryParameters, maxRange);
+            raycastCommands[index] = new(origin, math.normalize(math.mul(rotation, directions[index + indexOffset])), queryParameters, maxRange);
         }
     }
 }

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
@@ -67,7 +67,7 @@ namespace UnitySensors.Sensor.LiDAR
             _updateRaycastCommandsJob = new IUpdateRaycastCommandsJob()
             {
                 origin = _transform.position,
-                localToWorldMatrix = _transform.localToWorldMatrix,
+                rotation = _transform.rotation,
                 maxRange = maxRange,
                 queryParameters = new() { layerMask = _raycastLayerMask },
                 directions = _directions,
@@ -100,7 +100,7 @@ namespace UnitySensors.Sensor.LiDAR
         protected override IEnumerator UpdateSensor()
         {
             _updateRaycastCommandsJob.origin = _transform.position;
-            _updateRaycastCommandsJob.localToWorldMatrix = _transform.localToWorldMatrix;
+            _updateRaycastCommandsJob.rotation = _transform.rotation;
 
             JobHandle updateRaycastCommandsJobHandle = _updateRaycastCommandsJob.Schedule(pointsNum, 1024);
             JobHandle updateGaussianNoisesJobHandle = _updateGaussianNoisesJob.Schedule(pointsNum, 1, updateRaycastCommandsJobHandle);


### PR DESCRIPTION
Hello!

The current LiDAR output is affected by scale changes of the GameObject because the direction is multiplied by transform.localToWorldMatrix, which applies both rotation and scale.

This change uses only the rotation component, preventing scale from affecting the direction.

Thanks for the great library. We use it in our own project and came across this issue.