### PR TITLE
Add support for UCM, Double Sphere, KB4, and OCamCalib fisheye models

### DIFF
--- a/Packages/UnitySensors/Editor/CustomInspector/FisheyeCameraEditor.cs
+++ b/Packages/UnitySensors/Editor/CustomInspector/FisheyeCameraEditor.cs
@@ -9,11 +9,27 @@ namespace UnitySensors.Editor
         SerializedProperty cameraModelProp;
         SerializedProperty alphaProp;
         SerializedProperty betaProp;
+        SerializedProperty xiProp;
+        SerializedProperty kb4Prop;
+        SerializedProperty affineCoeffsProp;
+        SerializedProperty _a0Prop;
+        SerializedProperty _a1Prop;
+        SerializedProperty _a2Prop;
+        SerializedProperty _a3Prop;
+        SerializedProperty _a4Prop;
         SerializedProperty focalLengthProp;
         SerializedProperty principalPointProp;
         readonly string cameraModelLabel = nameof(FisheyeCameraSensor._cameraModel);
         readonly string alphaLabel = nameof(FisheyeCameraSensor._alpha);
         readonly string betaLabel = nameof(FisheyeCameraSensor._beta);
+        readonly string xiLabel = nameof(FisheyeCameraSensor._xi);
+        readonly string kb4Label = nameof(FisheyeCameraSensor._kb4);
+        readonly string affineCoeffsLabel = nameof(FisheyeCameraSensor._affineCoeffs);
+        readonly string _a0Label = nameof(FisheyeCameraSensor._a0);
+        readonly string _a1Label = nameof(FisheyeCameraSensor._a1);
+        readonly string _a2Label = nameof(FisheyeCameraSensor._a2);
+        readonly string _a3Label = nameof(FisheyeCameraSensor._a3);
+        readonly string _a4Label = nameof(FisheyeCameraSensor._a4);
         readonly string focalLengthLabel = nameof(FisheyeCameraSensor._focalLength);
         readonly string principalPointLabel = nameof(FisheyeCameraSensor._principalPoint);
         readonly string fovLabel = nameof(FisheyeCameraSensor._fov);
@@ -24,6 +40,14 @@ namespace UnitySensors.Editor
             cameraModelProp = serializedObject.FindProperty(cameraModelLabel);
             alphaProp = serializedObject.FindProperty(alphaLabel);
             betaProp = serializedObject.FindProperty(betaLabel);
+            xiProp = serializedObject.FindProperty(xiLabel);
+            kb4Prop = serializedObject.FindProperty(kb4Label);
+            affineCoeffsProp = serializedObject.FindProperty(affineCoeffsLabel);
+            _a0Prop = serializedObject.FindProperty(_a0Label);
+            _a1Prop = serializedObject.FindProperty(_a1Label);
+            _a2Prop = serializedObject.FindProperty(_a2Label);
+            _a3Prop = serializedObject.FindProperty(_a3Label);
+            _a4Prop = serializedObject.FindProperty(_a4Label);
             focalLengthProp = serializedObject.FindProperty(focalLengthLabel);
             principalPointProp = serializedObject.FindProperty(principalPointLabel);
         }
@@ -37,16 +61,38 @@ namespace UnitySensors.Editor
             EditorGUI.EndDisabledGroup();
 
             DrawPropertiesExcluding(serializedObject,
-                cameraModelLabel, alphaLabel, betaLabel, focalLengthLabel, principalPointLabel, fovLabel, scriptLabel);
+                cameraModelLabel, alphaLabel, betaLabel, xiLabel, kb4Label, affineCoeffsLabel, _a0Label, _a1Label, _a2Label, _a3Label, _a4Label, focalLengthLabel, principalPointLabel, fovLabel, scriptLabel);
 
             EditorGUILayout.PropertyField(cameraModelProp);
-            if (cameraModelProp.enumValueIndex == (int)FisheyeCameraSensor.CameraModel.EUCM)
+            switch (cameraModelProp.enumValueIndex)
             {
-                EditorGUILayout.PropertyField(alphaProp);
-                EditorGUILayout.PropertyField(betaProp);
-                EditorGUILayout.PropertyField(focalLengthProp);
-                EditorGUILayout.PropertyField(principalPointProp);
+                case (int)FisheyeCameraSensor.CameraModel.UCM:
+                    EditorGUILayout.PropertyField(alphaProp);
+                    break;
+                case (int)FisheyeCameraSensor.CameraModel.EUCM:
+                    EditorGUILayout.PropertyField(alphaProp);
+                    EditorGUILayout.PropertyField(betaProp);
+                    break;
+                case (int)FisheyeCameraSensor.CameraModel.DS:
+                    EditorGUILayout.PropertyField(alphaProp);
+                    EditorGUILayout.PropertyField(xiProp);
+                    break;
+                case (int)FisheyeCameraSensor.CameraModel.KB4:
+                    EditorGUILayout.PropertyField(kb4Prop);
+                    break;
+                case (int)FisheyeCameraSensor.CameraModel.OCAM:
+                    EditorGUILayout.PropertyField(affineCoeffsProp);
+                    EditorGUILayout.PropertyField(_a0Prop);
+                    EditorGUILayout.PropertyField(_a1Prop);
+                    EditorGUILayout.PropertyField(_a2Prop);
+                    EditorGUILayout.PropertyField(_a3Prop);
+                    EditorGUILayout.PropertyField(_a4Prop);
+                    break;
+                case (int)FisheyeCameraSensor.CameraModel.Equidistant:
+                    break;
             }
+            EditorGUILayout.PropertyField(focalLengthProp);
+            EditorGUILayout.PropertyField(principalPointProp);
             serializedObject.ApplyModifiedProperties();
         }
     }

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Camera/FisheyeCamera/FisheyeCameraSensor.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Camera/FisheyeCamera/FisheyeCameraSensor.cs
@@ -9,8 +9,12 @@ namespace UnitySensors.Sensor.Camera
     {
         public enum CameraModel
         {
-            Equidistant,
-            EUCM
+            UCM,
+            EUCM,
+            DS,
+            KB4,
+            OCAM,
+            Equidistant
         }
         [SerializeField]
         private Material _fisheyeMat;
@@ -24,6 +28,22 @@ namespace UnitySensors.Sensor.Camera
         internal float _alpha = 1.0f;
         [SerializeField, Min(0)]
         internal float _beta = 0.0f;
+        [SerializeField]
+        internal float _xi = 0.34f;
+        [SerializeField]
+        internal Vector4 _kb4 = new Vector4(-0.01f, 0.03f, -0.02f, 0.005f);
+        [SerializeField]
+        internal Vector4 _affineCoeffs = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);//c d e 1
+        [SerializeField]
+        internal float _a0 = 190.87f;
+        [SerializeField]
+        internal float _a1 = 0.0f;
+        [SerializeField]
+        internal float _a2 = 0.0f;
+        [SerializeField]
+        internal float _a3 = -0.000003f;
+        [SerializeField]
+        internal float _a4 = 0.0f;
         [SerializeField]
         internal Vector2 _focalLength = new Vector2(1.0f, 1.0f);
         [SerializeField]
@@ -59,14 +79,24 @@ namespace UnitySensors.Sensor.Camera
         {
             m_camera.RenderToCubemap(_cubemap);
 
-            _fisheyeMat.SetInteger("_Equidistant", _cameraModel == CameraModel.Equidistant ? 1 : 0);
+            _fisheyeMat.SetFloat("_CameraModel", (int)_cameraModel);
             _fisheyeMat.SetFloat("_Angle", _viewAngle);
             _fisheyeMat.SetFloat("_alpha", _alpha);
             _fisheyeMat.SetFloat("_beta", _beta);
+            _fisheyeMat.SetFloat("_xi", _xi);
+            _fisheyeMat.SetVector("_kb4", _kb4);
+            _fisheyeMat.SetVector("_affineCoeffs", _affineCoeffs);
+            _fisheyeMat.SetFloat("_a0", _a0);
+            _fisheyeMat.SetFloat("_a1", _a1);
+            _fisheyeMat.SetFloat("_a2", _a2);
+            _fisheyeMat.SetFloat("_a3", _a3);
+            _fisheyeMat.SetFloat("_a4", _a4);
             _fisheyeMat.SetFloat("_fx", _focalLength.x / _resolution.x);
             _fisheyeMat.SetFloat("_fy", _focalLength.y / _resolution.y);
             _fisheyeMat.SetFloat("_cx", _principalPoint.x / _resolution.x);
             _fisheyeMat.SetFloat("_cy", 1 - _principalPoint.y / _resolution.y);
+            _fisheyeMat.SetFloat(" _resolutionX", _resolution.x);
+            _fisheyeMat.SetFloat(" _resolutionY", _resolution.y);
             var eulerAngles = transform.rotation.eulerAngles;
             var rot = Quaternion.Euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
             var mat = Matrix4x4.TRS(Vector3.zero, rot, Vector3.one);

--- a/Packages/UnitySensors/Samples~/Runtime/Shaders/FisheyeCamera.shader
+++ b/Packages/UnitySensors/Samples~/Runtime/Shaders/FisheyeCamera.shader
@@ -5,13 +5,23 @@ Shader "UnitySensors/FisheyeCamera"
     {
         [NoScaleOffset] _MainTex ("Cubemap", Cube) = "" { }
         _Angle ("Angle", Range(90, 360)) = 180
-        _Equidistant ("Equidistant Projection", Integer) = 1
+        _CameraModel ("Camera Model", Range(0, 5)) = 0
         _alpha ("Alpha", Range(0, 1)) = 1
         _beta ("Beta", Float) = 1
+        _xi ("Xi", Float) = 0.34
+        _kb4 ("KB4 Coefficients", Vector) = (-0.01, 0.03, -0.02, 0.005)
+        _affineCoeffs ("OCAM Affine Coefficients (c, d, e, 1)", Vector) = (1, 0, 0, 1)
+        _a0 ("OCAM Unprojection Coefficients a0", float) = 190.87
+        _a1 ("OCAM Unprojection Coefficients a1", float) = 0
+        _a2 ("OCAM Unprojection Coefficients a2", float) = 0
+        _a3 ("OCAM Unprojection Coefficients a3", float) = -0.000003
+        _a4 ("OCAM Unprojection Coefficients a4", float) = 0
         _fx ("Normalized Focal Length X", Float) = 1
         _fy ("Normalized Focal Length Y", Float) = 1
         _cx ("Normalized Principal Point X", Float) = 0.5
         _cy ("Normalized Principal Point Y", Float) = 0.5
+        _resolutionX ("Resolution X", Float) = 1024
+        _resolutionY ("Resolution Y", Float) = 1024
     }
 
     Subshader
@@ -29,11 +39,21 @@ Shader "UnitySensors/FisheyeCamera"
             float4x4 _WorldTransform;
             float _alpha;
             float _beta;
+            float _xi;
+            float4 _kb4;
+            float4 _affineCoeffs;
+            float _a0;
+            float _a1;
+            float _a2;
+            float _a3;
+            float _a4;
             float _fx;
             float _fy;
             float _cx;
             float _cy;
-            int _Equidistant;
+            float _resolutionX;
+            float _resolutionY;
+            int _CameraModel;
 
             struct v2f
             {
@@ -48,7 +68,88 @@ Shader "UnitySensors/FisheyeCamera"
                 o.uv = v.texcoord.xy;
                 return o;
             }
-            
+            // Reference: https://github.com/eowjd0512/fisheye-calib-adapter
+            float3 UCMToDirection(float2 uv, float targetAngleRad)
+            {
+                float gamma = 1 - _alpha;
+                float2 uv2 = (uv - float2(_cx, _cy)) / float2(_fx, _fy) * gamma;
+                float r2 = dot(uv2, uv2);
+                float xi = _alpha / gamma;
+                float3 dir = (xi + sqrt(1 + (1 - xi * xi) * r2)) / (1 + r2) * float3(uv2, 1) - float3(0, 0, xi);
+                dir = normalize(dir);
+                return dir;
+            }
+            // Reference: https://github.com/eowjd0512/fisheye-calib-adapter
+            float3 EUCMToDirection(float2 uv)
+            {
+                float2 uv2 = (uv - float2(_cx, _cy)) / float2(_fx, _fy);
+                float r2 = dot(uv2, uv2);
+                float gamma = 1 - _alpha;
+                float z = (1 - _alpha * _alpha * _beta * r2) / (_alpha * sqrt(1 - (_alpha - gamma) * _beta * r2) + gamma);
+                float3 dir = float3(uv2, z);
+                dir = normalize(dir);
+                return dir;
+            }
+            // Reference: https://github.com/eowjd0512/fisheye-calib-adapter
+            float3 DSToDirection(float2 uv)
+            {
+                float2 uv2 = (uv - float2(_cx, _cy)) / float2(_fx, _fy);
+                float r2 = dot(uv2, uv2);
+                float mz = (1 - _alpha * _alpha *r2) / (_alpha * sqrt(1 - (2 * _alpha - 1) * r2) + 1 - _alpha);
+                float factor = (mz * _xi + sqrt(mz * mz + (1 - _xi * _xi) *r2)) / (mz * mz + r2);
+                float3 dir = factor * float3(uv2, mz) - float3(0, 0, _xi);
+                dir = normalize(dir);
+                return dir;
+            }
+            // Reference: https://github.com/eowjd0512/fisheye-calib-adapter
+            float3 KB4ToDirection(float2 uv)
+            {
+                float2 uv2 = (uv - float2(_cx, _cy)) / float2(_fx, _fy);
+                float r = length(uv2);
+                float theta = r;
+                for (int i = 0; i < 12; i++)
+                {
+                    float t2 = theta * theta;
+                    float t4 = t2 * t2;
+                    float t6 = t4 * t2;
+                    float t8 = t4 * t4;
+                    float f = theta * (1 + _kb4.x * t2 + _kb4.y * t4 + _kb4.z * t6 + _kb4.w * t8) - r;
+                    float df = 1 + 3 * _kb4.x * t2 + 5 * _kb4.y * t4 + 7 * _kb4.z * t6 + 9 * _kb4.w * t8;
+                    theta = theta - f / max(df, 1e-8);
+                }
+                float sin_theta = sin(theta);
+                float cos_theta = cos(theta);
+                float scale = sin_theta / max(r, 1e-8);
+                float x = uv2.x * scale;
+                float y = uv2.y * scale;
+                float z = cos_theta;
+                if (theta < 1e-8) // Handle the case when theta is very small to avoid numerical instability
+                {
+                    x = 0;
+                    y = 0;
+                    z = 1;
+                }
+                float3 dir = float3(x, y, z);
+                dir = normalize(dir);
+                return dir;
+            }
+            // Reference: https://github.com/eowjd0512/fisheye-calib-adapter
+            float3 OCAMToDirection(float2 uv)
+            {
+                float2 uv2 = uv - float2(_cx, _cy);
+                uv2 = uv2 * float2(_resolutionX, _resolutionY);
+                float2 xy = float2(uv2.x - uv2.y * _affineCoeffs.y, - uv2.x * _affineCoeffs.z + uv2.y * _affineCoeffs.x) 
+                / (_affineCoeffs.x - _affineCoeffs.y * _affineCoeffs.z);
+                float r = length(xy);
+                float r2 = r * r;
+                float r3 = r2 * r;
+                float r4 = r2 * r2;
+                float mz = _a0 + _a1 * r + _a2 * r2 + _a3 * r3 + _a4 * r4;
+                float3 dir = float3(xy, mz);
+                dir = normalize(dir);
+                return dir;
+            }
+
             // Reference: https://github.com/prefrontalcortex/DomeTools
             float3 EquidistantToDirection(float2 uv, float targetAngleRad)
             {
@@ -60,25 +161,31 @@ Shader "UnitySensors/FisheyeCamera"
                 dir = normalize(dir);
                 return dir;
             }
-            
-            float3 EUCMToDirection(float2 uv)
-            {
-                float2 uv2 = (uv - float2(_cx, _cy)) / float2(_fx, _fy);
-                float r2 = dot(uv2, uv2);
-                float gamma = 1 - _alpha;
-                float z = (1 - _alpha * _alpha * _beta * r2) / (_alpha * sqrt(1 - (_alpha - gamma) * _beta * r2) + gamma);
-                float3 dir = float3(uv2, z);
-                dir = normalize(dir);
-                return dir;
-            }
 
             fixed4 frag(v2f i) : COLOR
             {
-                float3 dir;
-                if (_Equidistant)
-                    dir = EquidistantToDirection(i.uv, radians(_Angle));
-                else
-                    dir = EUCMToDirection(i.uv);
+                float3 dir = float3(0, 0, 1);
+               switch (_CameraModel)
+                {
+                    case 0: // UCM
+                        dir = UCMToDirection(i.uv, radians(_Angle));
+                        break;
+                    case 1: // EUCM
+                        dir = EUCMToDirection(i.uv);
+                        break;
+                    case 2: // DS
+                        dir = DSToDirection(i.uv);
+                        break;
+                    case 3: // KB4
+                        dir = KB4ToDirection(i.uv);
+                        break;
+                    case 4: // OCAM
+                        dir = OCAMToDirection(i.uv);
+                        break;
+                    case 5: // Equidistant
+                        dir = EquidistantToDirection(i.uv, radians(_Angle));
+                        break;
+                }
                 // Apply fisheye mask based on the angle
                 float angle = acos(dir.z);
                 float3 fisheyeMask = angle <= radians(_Angle) * 0.5;

--- a/Packages/UnitySensors/Samples~/Scenes/Camera/Demo_FisheyeCamera.unity
+++ b/Packages/UnitySensors/Samples~/Scenes/Camera/Demo_FisheyeCamera.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 10
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 12
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -66,6 +66,9 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -119,6 +122,172 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &132275023
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 952137284}
+    m_Modifications:
+    - target: {fileID: 2845392135782433157, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _image
+      value: 
+      objectReference: {fileID: 1638838926}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cameraModel
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cubemapResolution
+      value: 512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074865834702253757, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_Name
+      value: FisheyeCamera_EUCM
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 258ef1358d72c2f47b009c2ea3644b8d, type: 3}
+--- !u!1001 &330999660
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 952137284}
+    m_Modifications:
+    - target: {fileID: 2845392135782433157, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _image
+      value: 
+      objectReference: {fileID: 1961524835}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cameraModel
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cubemapResolution
+      value: 512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074865834702253757, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_Name
+      value: FisheyeCamera_KB4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 258ef1358d72c2f47b009c2ea3644b8d, type: 3}
 --- !u!1 &407419871
 GameObject:
   m_ObjectHideFlags: 0
@@ -144,8 +313,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 407419871}
   m_Enabled: 1
-  serializedVersion: 11
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -307,6 +477,10 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1896987095}
+  - {fileID: 1638838925}
+  - {fileID: 1954785137}
+  - {fileID: 1961524834}
+  - {fileID: 841821840}
   - {fileID: 739881681}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -315,6 +489,94 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &700684083
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 952137284}
+    m_Modifications:
+    - target: {fileID: 2845392135782433157, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _image
+      value: 
+      objectReference: {fileID: 841821841}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _a3
+      value: -0.000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cameraModel
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cubemapResolution
+      value: 512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074865834702253757, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_Name
+      value: FisheyeCamera_OCAM
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 258ef1358d72c2f47b009c2ea3644b8d, type: 3}
 --- !u!1 &739881680
 GameObject:
   m_ObjectHideFlags: 0
@@ -327,7 +589,7 @@ GameObject:
   - component: {fileID: 739881683}
   - component: {fileID: 739881682}
   m_Layer: 5
-  m_Name: EUCM
+  m_Name: EquidistantEquidistant
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -347,11 +609,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 445338817}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 480, y: 0}
-  m_SizeDelta: {x: 1024, y: 1024}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0.000061035156, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 1, y: 0}
 --- !u!114 &739881682
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -387,11 +649,95 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 739881680}
   m_CullTransparentMesh: 1
+--- !u!1 &841821839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 841821840}
+  - component: {fileID: 841821842}
+  - component: {fileID: 841821841}
+  m_Layer: 5
+  m_Name: OCAM
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &841821840
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 841821839}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 445338817}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &841821841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 841821839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &841821842
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 841821839}
+  m_CullTransparentMesh: 1
+--- !u!4 &876952661 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+    type: 3}
+  m_PrefabInstance: {fileID: 132275023}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &952137284 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
     type: 3}
   m_PrefabInstance: {fileID: 1800507287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1058384350 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1629240994}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1437038471
 GameObject:
@@ -473,11 +819,11 @@ PrefabInstance:
         type: 3}
       propertyPath: _image
       value: 
-      objectReference: {fileID: 739881682}
+      objectReference: {fileID: 1896987096}
     - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}
       propertyPath: _cameraModel
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}
@@ -487,7 +833,7 @@ PrefabInstance:
     - target: {fileID: 6074865834702253757, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}
       propertyPath: m_Name
-      value: FisheyeCamera_EUCM
+      value: FisheyeCamera_UCM
       objectReference: {fileID: 0}
     - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}
@@ -550,6 +896,167 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1440317406}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1617801986 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+    type: 3}
+  m_PrefabInstance: {fileID: 330999660}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1629240994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 952137284}
+    m_Modifications:
+    - target: {fileID: 2845392135782433157, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _image
+      value: 
+      objectReference: {fileID: 1954785138}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cameraModel
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: _cubemapResolution
+      value: 512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074865834702253757, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_Name
+      value: FisheyeCamera_DS
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 258ef1358d72c2f47b009c2ea3644b8d, type: 3}
+--- !u!1 &1638838924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1638838925}
+  - component: {fileID: 1638838927}
+  - component: {fileID: 1638838926}
+  m_Layer: 5
+  m_Name: EUCM
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1638838925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638838924}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9000001, y: 0.9000001, z: 0.9000001}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 445338817}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1638838926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638838924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1638838927
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638838924}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1800507287
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -624,11 +1131,27 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6023160554775521649}
+      addedObject: {fileID: 1440317407}
     - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1440317407}
+      addedObject: {fileID: 876952661}
+    - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1058384350}
+    - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1617801986}
+    - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1950569944}
+    - targetCorrespondingSourceObject: {fileID: 2848956544552890604, guid: 581b84ef57339314c92df1cef0a06b47,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6023160554775521649}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 581b84ef57339314c92df1cef0a06b47, type: 3}
 --- !u!1 &1896987094
@@ -643,7 +1166,7 @@ GameObject:
   - component: {fileID: 1896987097}
   - component: {fileID: 1896987096}
   m_Layer: 5
-  m_Name: Equidistant
+  m_Name: UCM
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -663,11 +1186,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 445338817}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -480, y: 0}
-  m_SizeDelta: {x: 1024, y: 1024}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -0.000061035156, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1896987096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -702,6 +1225,156 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1896987094}
+  m_CullTransparentMesh: 1
+--- !u!4 &1950569944 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7895219417869400955, guid: 258ef1358d72c2f47b009c2ea3644b8d,
+    type: 3}
+  m_PrefabInstance: {fileID: 700684083}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1954785136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1954785137}
+  - component: {fileID: 1954785139}
+  - component: {fileID: 1954785138}
+  m_Layer: 5
+  m_Name: DS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1954785137
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1954785136}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 445338817}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000061035156, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &1954785138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1954785136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1954785139
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1954785136}
+  m_CullTransparentMesh: 1
+--- !u!1 &1961524833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1961524834}
+  - component: {fileID: 1961524836}
+  - component: {fileID: 1961524835}
+  m_Layer: 5
+  m_Name: KB4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1961524834
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961524833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 445338817}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.000061035156, y: 0}
+  m_SizeDelta: {x: 314, y: 314}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1961524835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961524833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1961524836
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961524833}
   m_CullTransparentMesh: 1
 --- !u!1 &2021466618
 GameObject:
@@ -813,11 +1486,11 @@ PrefabInstance:
         type: 3}
       propertyPath: _image
       value: 
-      objectReference: {fileID: 1896987096}
+      objectReference: {fileID: 739881682}
     - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}
       propertyPath: _cameraModel
-      value: 0
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6005907688980854987, guid: 258ef1358d72c2f47b009c2ea3644b8d,
         type: 3}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following sensors are available inside :
 - RGB Camera
 - RGBD Camera
 - Panoramic Camera
-- Fisheye Camera (Equidistant and [EUCM][external-EUCM-link] models with adjustable parameters)
+- Fisheye Camera ([UCM][external-UCM-link], [EUCM][external-EUCM-link], [Double Sphere][external-DS-link], [Kannala-Brandt (KB4)][external-KB4-link], [OCamCalib][external-OCamCalib-link], and Equidistant models with adjustable parameters)
 - IMU
 - GNSS
 - (GroundTruth)
@@ -98,7 +98,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 <!-- LINK GROUP -->
 
+[external-UCM-link]: https://arxiv.org/abs/2407.12405
 [external-EUCM-link]: https://github.com/ethz-asl/kalibr/wiki/supported-models
+[external-DS-link]: https://github.com/ethz-asl/kalibr/wiki/supported-models
+[external-KB4-link]: https://arxiv.org/abs/2407.12405
+[external-OCamCalib-link]: https://arxiv.org/abs/2407.12405
 [external-unity-shield]: https://img.shields.io/badge/Unity3D-%3E%202022.3-blue?style=flat-square&logo=unity
 [external-unity-link]: https://unity.com/
 [external-ros-shield]: https://img.shields.io/badge/ROS-1%7C2-blue?style=flat-square&logo=ros


### PR DESCRIPTION
**Description**

This PR extends the existing camera models in UnitySensors to support a wider range of industry-standard fisheye projections.

While the current EUCM and Equidistant fisheye models provide a solid foundation, they are not always compatible with many established fisheye algorithms used in robotics and computer vision research. To bridge this gap, I have implemented four additional projection models:

-   UCM (Unified Camera Model)

-   Double Sphere

-   KB4 (Kannala-Brandt)

-   OCamCalib (Omnidirectional Camera)

With these additions, the project now covers the most common fisheye models used in state-of-the-art research, making it significantly more versatile for users working on wide-angle perception and navigation.

The mathematical foundations for these implementations can be found in:

    Fisheye-Calib-Adapter: An Easy Tool for Fisheye Camera Model Conversion ([arXiv:2407.12405](https://arxiv.org/abs/2407.12405))

**Changes**

    Extended the fisheye sensor module to include the four new projection types.

    Updated the parameter configuration to allow for seamless switching between models.
<img width="1481" height="654" alt="fisheye_test" src="https://github.com/user-attachments/assets/1d199755-5b0a-4370-a2db-84c1de9e4be8" />
I am a big fan of UnitySensors and hope these contributions help the project continue to grow and support more advanced robotics applications!