### PR TITLE
Add contact (bumper) sensor with Bool and WrenchStamped publishers

### DIFF
--- a/Packages/UnitySensors/Runtime/Scripts/DataType/Sensor/ContactData.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/DataType/Sensor/ContactData.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace UnitySensors.DataType.Sensor
+{
+    [System.Serializable]
+    public struct ContactData
+    {
+        public string colliderName;
+        public Vector3 position;
+        public Vector3 normal;
+        public Vector3 force;
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/DataType/Sensor/ContactData.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/DataType/Sensor/ContactData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19d1bbf628364466acd604951487b7a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IContactDataInterface.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IContactDataInterface.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+using UnitySensors.DataType.Sensor;
+
+namespace UnitySensors.Interface.Sensor
+{
+    public interface IContactDataInterface
+    {
+        public bool isContact { get; }
+        public Vector3 totalForce { get; }
+        public Vector3 totalTorque { get; }
+        public Vector3 localTotalForce { get; }
+        public Vector3 localTotalTorque { get; }
+        public IReadOnlyList<ContactData> contacts { get; }
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IContactDataInterface.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IContactDataInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 551179d557c14100b6453a754f07f0b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IWrenchInterface.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IWrenchInterface.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace UnitySensors.Interface.Sensor
+{
+    /// <summary>
+    /// A force/torque pair expressed in the sensor's local frame.
+    /// </summary>
+    public interface IWrenchInterface
+    {
+        public Vector3 force { get; }
+        public Vector3 torque { get; }
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IWrenchInterface.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Sensor/IWrenchInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de3dd290f0a6464fb5f084d7ecc1ea2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Std/IBoolStateInterface.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Std/IBoolStateInterface.cs
@@ -1,0 +1,7 @@
+namespace UnitySensors.Interface.Std
+{
+    public interface IBoolStateInterface
+    {
+        public bool state { get; }
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/Interfaces/Std/IBoolStateInterface.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Interfaces/Std/IBoolStateInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05b3402cc5ec4adc9cdcd41da04f57d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de03d6b510604e90981c88a5b984d0da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactEventRelay.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactEventRelay.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace UnitySensors.Sensor.Contact
+{
+    /// <summary>
+    /// Forwards OnCollision* messages from a collider-only child GameObject to
+    /// the ContactSensor on the owning body link. Added automatically by
+    /// ContactSensor; not meant to be attached by hand.
+    /// </summary>
+    [AddComponentMenu("")]
+    public class ContactEventRelay : MonoBehaviour
+    {
+        private ContactSensor _sensor;
+
+        public void Initialize(ContactSensor sensor)
+        {
+            _sensor = sensor;
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            if (_sensor != null) _sensor.HandleRelayedCollisionEnter(collision);
+        }
+
+        private void OnCollisionStay(Collision collision)
+        {
+            if (_sensor != null) _sensor.HandleRelayedCollisionStay(collision);
+        }
+
+        private void OnCollisionExit(Collision collision)
+        {
+            if (_sensor != null) _sensor.HandleRelayedCollisionExit(collision);
+        }
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactEventRelay.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactEventRelay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e853ad165a164f55b26ebb55f8b91ca8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactSensor.cs
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactSensor.cs
@@ -1,0 +1,163 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+using UnitySensors.Attribute;
+using UnitySensors.DataType.Sensor;
+using UnitySensors.Interface.Sensor;
+using UnitySensors.Interface.Std;
+
+namespace UnitySensors.Sensor.Contact
+{
+    public class ContactSensor : UnitySensor, IContactDataInterface, IBoolStateInterface, IWrenchInterface
+    {
+        [SerializeField, ReadOnly]
+        private bool _isContact;
+        [SerializeField, ReadOnly]
+        private List<ContactData> _contacts = new List<ContactData>();
+
+        private Dictionary<Collider, ContactData> _activeContacts = new Dictionary<Collider, ContactData>();
+        private List<Collider> _removeBuffer = new List<Collider>();
+        private Vector3 _totalForce;
+        private Vector3 _totalTorque;
+
+        public bool isContact { get => _isContact; }
+        public Vector3 totalForce { get => _totalForce; }
+        public Vector3 totalTorque { get => _totalTorque; }
+        public Vector3 localTotalForce { get => transform.InverseTransformDirection(_totalForce); }
+        public Vector3 localTotalTorque { get => transform.InverseTransformDirection(_totalTorque); }
+        public IReadOnlyList<ContactData> contacts { get => _contacts; }
+
+        // Generic serializer sources: bumper state and the net contact wrench
+        // in the sensor's local frame.
+        bool IBoolStateInterface.state { get => _isContact; }
+        Vector3 IWrenchInterface.force { get => localTotalForce; }
+        Vector3 IWrenchInterface.torque { get => localTotalTorque; }
+
+        protected override void Init()
+        {
+            // OnCollision* messages are delivered to the GameObject that holds
+            // the touched collider, which for articulated robots is usually a
+            // collider-only child of the body link. Put a relay on each of those
+            // children so their events reach this sensor. Children that have
+            // their own Rigidbody/ArticulationBody belong to another body, so
+            // recursion stops there; use RegisterCollider() to cover colliders
+            // outside this default scan.
+            AttachRelays(transform);
+        }
+
+        /// <summary>
+        /// Relay OnCollision* events from the given collider's GameObject to
+        /// this sensor. Use this when the collider sits outside the default
+        /// scan, e.g. on a child GameObject that carries its own body.
+        /// </summary>
+        public void RegisterCollider(Collider target)
+        {
+            if (target == null || target.gameObject == gameObject) return;
+            if (target.GetComponent<ContactEventRelay>() == null)
+            {
+                target.gameObject.AddComponent<ContactEventRelay>().Initialize(this);
+            }
+        }
+
+        private void AttachRelays(Transform target)
+        {
+            if (target != transform &&
+                (target.GetComponent<Rigidbody>() != null || target.GetComponent<ArticulationBody>() != null))
+            {
+                return;
+            }
+
+            if (target != transform &&
+                target.GetComponent<Collider>() != null &&
+                target.GetComponent<ContactEventRelay>() == null)
+            {
+                target.gameObject.AddComponent<ContactEventRelay>().Initialize(this);
+            }
+
+            for (int i = 0; i < target.childCount; i++)
+            {
+                AttachRelays(target.GetChild(i));
+            }
+        }
+
+        // Colliders on the same GameObject as the body report here directly;
+        // collider-only children report through ContactEventRelay.
+        private void OnCollisionEnter(Collision collision)
+        {
+            UpdateContact(collision);
+        }
+
+        private void OnCollisionStay(Collision collision)
+        {
+            UpdateContact(collision);
+        }
+
+        private void OnCollisionExit(Collision collision)
+        {
+            _activeContacts.Remove(collision.collider);
+        }
+
+        internal void HandleRelayedCollisionEnter(Collision collision)
+        {
+            UpdateContact(collision);
+        }
+
+        internal void HandleRelayedCollisionStay(Collision collision)
+        {
+            UpdateContact(collision);
+        }
+
+        internal void HandleRelayedCollisionExit(Collision collision)
+        {
+            _activeContacts.Remove(collision.collider);
+        }
+
+        private void UpdateContact(Collision collision)
+        {
+            if (collision.contactCount == 0) return;
+
+            ContactPoint contactPoint = collision.GetContact(0);
+            ContactData contact = new ContactData();
+            contact.colliderName = collision.collider.name;
+            contact.position = contactPoint.point;
+            contact.normal = contactPoint.normal;
+            contact.force = collision.impulse / Time.fixedDeltaTime;
+            _activeContacts[collision.collider] = contact;
+        }
+
+        protected override IEnumerator UpdateSensor()
+        {
+            // A collider destroyed while touching never sends OnCollisionExit,
+            // so drop destroyed keys before aggregating.
+            _removeBuffer.Clear();
+            foreach (Collider collider in _activeContacts.Keys)
+            {
+                if (collider == null) _removeBuffer.Add(collider);
+            }
+            foreach (Collider collider in _removeBuffer)
+            {
+                _activeContacts.Remove(collider);
+            }
+
+            _contacts.Clear();
+            _totalForce = Vector3.zero;
+            _totalTorque = Vector3.zero;
+
+            Vector3 origin = transform.position;
+            foreach (ContactData contact in _activeContacts.Values)
+            {
+                _contacts.Add(contact);
+                _totalForce += contact.force;
+                _totalTorque += Vector3.Cross(contact.position - origin, contact.force);
+            }
+            _isContact = _contacts.Count > 0;
+
+            yield return null;
+        }
+
+        protected override void OnSensorDestroy()
+        {
+        }
+    }
+}

--- a/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactSensor.cs.meta
+++ b/Packages/UnitySensors/Runtime/Scripts/Sensors/Contact/ContactSensor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cdc18db19914e8b8a05fc691fb8a871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/GeometryMsgs/WrenchStampedMsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/GeometryMsgs/WrenchStampedMsgPublisher.cs
@@ -1,0 +1,10 @@
+using RosMessageTypes.Geometry;
+
+using UnitySensors.ROS.Serializer.Geometry;
+
+namespace UnitySensors.ROS.Publisher.Geometry
+{
+    public class WrenchStampedMsgPublisher : RosMsgPublisher<WrenchStampedMsgSerializer, WrenchStampedMsg>
+    {
+    }
+}

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/GeometryMsgs/WrenchStampedMsgPublisher.cs.meta
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/GeometryMsgs/WrenchStampedMsgPublisher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b6ee44b07d1418fb3e05fd0870921da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs.meta
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3486f3df896046dbb3da1311547da094
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs/BoolMsgPublisher.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs/BoolMsgPublisher.cs
@@ -1,0 +1,10 @@
+using RosMessageTypes.Std;
+
+using UnitySensors.ROS.Serializer.Std;
+
+namespace UnitySensors.ROS.Publisher.Std
+{
+    public class BoolMsgPublisher : RosMsgPublisher<BoolMsgSerializer, BoolMsg>
+    {
+    }
+}

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs/BoolMsgPublisher.cs.meta
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Publishers/StdMsgs/BoolMsgPublisher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b21eb530bb194d13a3fbb60776470bc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/GeometryMsgs/WrenchStampedMsgSerializer.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/GeometryMsgs/WrenchStampedMsgSerializer.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+using Unity.Robotics.ROSTCPConnector.ROSGeometry;
+using RosMessageTypes.Geometry;
+
+using UnitySensors.Attribute;
+using UnitySensors.Interface.Sensor;
+using UnitySensors.ROS.Serializer.Std;
+
+namespace UnitySensors.ROS.Serializer.Geometry
+{
+    [System.Serializable]
+    public class WrenchStampedMsgSerializer : RosMsgSerializer<WrenchStampedMsg>
+    {
+        [SerializeField, Interface(typeof(IWrenchInterface))]
+        private Object _source;
+        [SerializeField]
+        private HeaderSerializer _header;
+
+        private IWrenchInterface _sourceInterface;
+
+        public override void Init()
+        {
+            base.Init();
+            _header.Init();
+            _sourceInterface = _source as IWrenchInterface;
+        }
+
+        public override WrenchStampedMsg Serialize()
+        {
+            _msg.header = _header.Serialize();
+            // IWrenchInterface vectors are already in the header frame
+            // (the sensor's local frame).
+            _msg.wrench.force = _sourceInterface.force.To<FLU>();
+            _msg.wrench.torque = _sourceInterface.torque.To<FLU>();
+            return _msg;
+        }
+    }
+}

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/GeometryMsgs/WrenchStampedMsgSerializer.cs.meta
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/GeometryMsgs/WrenchStampedMsgSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a0ebfa03874f1e9b0ee9705b930f8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/StdMsgs/BoolMsgSerializer.cs
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/StdMsgs/BoolMsgSerializer.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using RosMessageTypes.Std;
+
+using UnitySensors.Attribute;
+using UnitySensors.Interface.Std;
+
+namespace UnitySensors.ROS.Serializer.Std
+{
+    [System.Serializable]
+    public class BoolMsgSerializer : RosMsgSerializer<BoolMsg>
+    {
+        [SerializeField, Interface(typeof(IBoolStateInterface))]
+        private Object _source;
+
+        private IBoolStateInterface _sourceInterface;
+
+        public override void Init()
+        {
+            base.Init();
+            _sourceInterface = _source as IBoolStateInterface;
+        }
+
+        public override BoolMsg Serialize()
+        {
+            _msg.data = _sourceInterface.state;
+            return _msg;
+        }
+    }
+}

--- a/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/StdMsgs/BoolMsgSerializer.cs.meta
+++ b/Packages/UnitySensorsROS/Runtime/Scripts/Serializers/StdMsgs/BoolMsgSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff6e550d839c40a7830b21731c11e118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following sensors are available inside :
 - Fisheye Camera ([UCM][external-UCM-link], [EUCM][external-EUCM-link], [Double Sphere][external-DS-link], [Kannala-Brandt (KB4)][external-KB4-link], [OCamCalib][external-OCamCalib-link], and Equidistant models with adjustable parameters)
 - IMU
 - GNSS
+- Contact (Bumper)
 - (GroundTruth)
 - (TF)
 


### PR DESCRIPTION
# Summary
This PR adds a contact (bumper) sensor to UnitySensors, following the existing sensor architecture (one small, self-contained sensor per PR). It detects collisions on the body it is attached to and publishes bumper-style contact state and the net contact wrench to ROS 2.

- UnitySensors: ContactSensor + ContactEventRelay (core, ROS-independent)
- UnitySensorsROS: BoolMsgPublisher (std_msgs/Bool) and WrenchStampedMsgPublisher (geometry_msgs/WrenchStamped)

Purely additive: no existing files are modified except the sensor list in README.md, and no asmdef or dependency changes are needed.

# Design
Core (Packages/UnitySensors)

- ContactSensor derives from UnitySensor and uses the standard _frequency / Init() / UpdateSensor() lifecycle. Collisions are accumulated in OnCollisionEnter/Stay/Exit and only aggregated at the sensor rate, so physics-rate events never leak through faster than frequency.
- Exposed via IContactDataInterface (mirrors IImuDataInterface): isContact, per-contact list (ContactData: collider name, position, normal, force estimated from Collision.impulse / fixedDeltaTime), world-frame totalForce / totalTorque, and localTotalForce / localTotalTorque (sensor-frame accessors, same pattern as the IMU's local* properties).
- Collider-only children: Unity delivers OnCollision* messages to the GameObject holding the touched collider. For articulated robots the colliders usually live on child GameObjects of the body link, so ContactSensor automatically attaches a lightweight ContactEventRelay to collider children (recursion stops at children that carry their own Rigidbody/ArticulationBody — those belong to another body). For setups outside this default scan, the public RegisterCollider(Collider) API lets the integrator wire any collider explicitly.
- A collider destroyed mid-contact never sends OnCollisionExit; destroyed keys are pruned every sensor tick so isContact cannot get stuck.

ROS (Packages/UnitySensorsROS)

- The serializers bind to generic source interfaces rather than the contact sensor itself, so they stay reusable: BoolMsgSerializer reads IBoolStateInterface (any boolean-state sensor) and WrenchStampedMsgSerializer reads IWrenchInterface (a local-frame force/torque pair — e.g. a future force-torque sensor can publish through the same serializer). ContactSensor implements both. Publishers are the usual thin RosMsgPublisher subclasses.
- The wrench is expressed in the header frame (the sensor link), converted with .To<FLU>().
- Only message types shipped with ROS-TCP-Connector are used — no custom .msg files.

# Validation
Tested end-to-end inside a ROS 2 (Humble) robot simulator built on this package (Unity 6000.3, Linux player): a 1 kg box with a contact sensor spawned 0.5 m above the ground —

- while falling, /contact publishes false; on landing a false → true transition is observed and persists at rest (including after the body sleeps)
- the resting /contact/wrench force points along the link-frame +z and matches the measured weight of the resting stack
- sensor at 20 Hz with the publisher rate decoupled from the physics rate

# Out of scope (possible follow-ups)
- Sample scene/prefab (a meaningful demo needs a floor + falling body scene; happy to add one in a follow-up)
- Publishing the per-contact array (no suitable standard message; would require a custom .msg)
- Collider/layer filtering to observe only a subset of the link's colliders